### PR TITLE
build: add direct url to prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Connect to Supabase
 POSTGRES_PRISMA_URL="postgresql://postgres:[YOUR-PASSWORD]@localhost:54322/postgres"
+DIRECT_URL="postgresql://postgres:[YOUR-PASSWORD]@localhost:54322/postgres"
 NEXT_PUBLIC_SUPABASE_URL=<your_supabase_project_url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your_supabase_anon_key>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,8 +4,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("POSTGRES_PRISMA_URL")
+  provider  = "postgresql"
+  url       = env("POSTGRES_PRISMA_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model Employee {


### PR DESCRIPTION
Add the `directUrl` property to the Prisma schema to allow migrations. I do not have a lot of knowledge of why it did not work with the previous port (6432). Need to check that later on. Still merging this, because production is currently broken because of it.